### PR TITLE
chore: move search client to its own module

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -13,16 +13,11 @@ import {
 } from '@heroicons/react/24/outline';
 import { createQuerySuggestionsPlugin } from '@algolia/autocomplete-plugin-query-suggestions';
 import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-plugin-recent-searches';
-import algoliasearch from 'algoliasearch';
 
-import { cx } from '../utils';
+import { cx, searchClient } from '../utils';
 import { currencies, navigation, footerNavigation, perks } from '../mock';
 import { Autocomplete } from './Autocomplete';
 import { AutocompleteItem } from './AutocompleteItem';
-
-const appId = 'latency';
-const apiKey = '6be0576ff61c053d5f9a3225e2a90f76';
-const searchClient = algoliasearch(appId, apiKey);
 
 export default function Layout({ children }: PropsWithChildren) {
   const router = useRouter();

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './cx';
+export * from './searchClient';

--- a/utils/searchClient.ts
+++ b/utils/searchClient.ts
@@ -1,0 +1,6 @@
+import algoliasearch from 'algoliasearch';
+
+const appId = 'latency';
+const apiKey = '6be0576ff61c053d5f9a3225e2a90f76';
+
+export const searchClient = algoliasearch(appId, apiKey);


### PR DESCRIPTION
This moves the search client to its own module. This is a pattern we want to encourage in general so users avoid instantiating the client in the render function, causing multiple instances to be created and the cache not to work.