### PR TITLE
refactor: export components from barrel

### DIFF
--- a/components/index.ts
+++ b/components/index.ts
@@ -1,1 +1,3 @@
+export * from './Autocomplete';
+export * from './AutocompleteItem';
 export * from './TrendingItem';

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -16,8 +16,7 @@ import { createLocalStorageRecentSearchesPlugin } from '@algolia/autocomplete-pl
 
 import { cx, searchClient } from '../utils';
 import { navigation, footerNavigation, perks } from '../mock';
-import { Autocomplete } from './Autocomplete';
-import { AutocompleteItem } from './AutocompleteItem';
+import { Autocomplete, AutocompleteItem } from '../components';
 import { useLazyRef } from '../hooks';
 
 export default function Layout({ children }: PropsWithChildren) {


### PR DESCRIPTION
This re-exports components from a barrel file.

>**Note**
>I didn't export `layout.tsx` because I intend to move it, but I'm waiting for the merge of the search page to avoid generating huge conflicts.